### PR TITLE
feat(k8s/data): add new data types based on SIG plans

### DIFF
--- a/k8s/data/binding.go
+++ b/k8s/data/binding.go
@@ -2,9 +2,9 @@ package data
 
 import (
 	"github.com/deis/steward-framework/lib"
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/pkg/api/unversioned"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type BindingState string

--- a/k8s/data/binding.go
+++ b/k8s/data/binding.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"github.com/deis/steward-framework/lib"
 	"k8s.io/client-go/1.4/pkg/api"
 	"k8s.io/client-go/1.4/pkg/api/unversioned"
 	"k8s.io/client-go/1.4/pkg/api/v1"
@@ -23,9 +24,9 @@ type Binding struct {
 }
 
 type BindingSpec struct {
-	InstanceRef api.ObjectReference    `json:"instance_ref"`
-	Parameters  map[string]interface{} `json:"parameters"`
-	SecretName  string                 `json:"secret_name"`
+	InstanceRef api.ObjectReference `json:"instance_ref"`
+	Parameters  lib.JSONObject      `json:"parameters"`
+	SecretName  string              `json:"secret_name"`
 }
 
 type BindingStatus struct {

--- a/k8s/data/binding.go
+++ b/k8s/data/binding.go
@@ -15,8 +15,8 @@ const (
 )
 
 type Binding struct {
-	kunversioned.TypeMeta
-	kapi.ObjectMeta
+	unversioned.TypeMeta
+	api.ObjectMeta
 
 	Spec   BindingSpec
 	Status BindingStatus

--- a/k8s/data/binding.go
+++ b/k8s/data/binding.go
@@ -1,0 +1,33 @@
+package data
+
+import (
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/unversioned"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+)
+
+type BindingState string
+
+const (
+	BindingStatePending BindingState = "Pending"
+	BindingStateBound   BindingState = "Bound"
+	BindingStateFailed  BindingState = "Failed"
+)
+
+type Binding struct {
+	kunversioned.TypeMeta
+	kapi.ObjectMeta
+
+	Spec   BindingSpec
+	Status BindingStatus
+}
+
+type BindingSpec struct {
+	InstanceRef api.ObjectReference    `json:"instance_ref"`
+	Parameters  map[string]interface{} `json:"parameters"`
+	SecretName  string                 `json:"secret_name"`
+}
+
+type BindingStatus struct {
+	State BindingState
+}

--- a/k8s/data/binding.go
+++ b/k8s/data/binding.go
@@ -4,7 +4,6 @@ import (
 	"github.com/deis/steward-framework/lib"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 type BindingState string

--- a/k8s/data/broker.go
+++ b/k8s/data/broker.go
@@ -1,0 +1,32 @@
+package data
+
+import (
+	"k8s.io/client-go/1.4/pkg/api/unversioned"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+)
+
+type BrokerState string
+
+const (
+	BrokerStatePending   BrokerState = "Pending"
+	BrokerStateAvailable BrokerState = "Available"
+	BrokerStateFailed    BrokerState = "Failed"
+)
+
+type Broker struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	Spec   BrokerSpec
+	Status BrokerStatus
+}
+
+type BrokerSpec struct {
+	URL      string `json:"url"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type BrokerStatus struct {
+	State BrokerState `json:"state"`
+}

--- a/k8s/data/broker.go
+++ b/k8s/data/broker.go
@@ -1,8 +1,8 @@
 package data
 
 import (
-	"k8s.io/client-go/1.4/pkg/api/unversioned"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type BrokerState string

--- a/k8s/data/instance.go
+++ b/k8s/data/instance.go
@@ -1,0 +1,36 @@
+package data
+
+import (
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/unversioned"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+)
+
+type Instance struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	Spec   InstanceSpec   `json:"spec"`
+	Status InstanceStatus `json:"status"`
+}
+
+type InstanceSpec struct {
+	ID              string              `json:"id"`
+	ServiceClassRef api.ObjectReference `json:"service_class_ref"`
+	// PlanName is the reference to the ServicePlan for this instance.
+	PlanName string
+
+	Parameters map[string]interface{}
+}
+
+type InstanceStatus struct {
+	Status InstanceState `json:"status"`
+}
+
+type InstanceState string
+
+const (
+	InstanceStatePending     InstanceState = "Pending"
+	InstanceStateProvisioned InstanceState = "Provisioned"
+	InstanceStateFailed      InstanceState = "Failed"
+)

--- a/k8s/data/instance.go
+++ b/k8s/data/instance.go
@@ -1,9 +1,9 @@
 package data
 
 import (
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/pkg/api/unversioned"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type Instance struct {

--- a/k8s/data/service_class.go
+++ b/k8s/data/service_class.go
@@ -1,9 +1,9 @@
 package data
 
 import (
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/pkg/api/unversioned"
-	"k8s.io/client-go/1.4/pkg/api/v1"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 type ServiceClass struct {

--- a/k8s/data/service_class.go
+++ b/k8s/data/service_class.go
@@ -1,0 +1,25 @@
+package data
+
+import (
+	"k8s.io/client-go/1.4/pkg/api"
+	"k8s.io/client-go/1.4/pkg/api/unversioned"
+	"k8s.io/client-go/1.4/pkg/api/v1"
+)
+
+type ServiceClass struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+	BrokerRef            api.ObjectReference `json:"broker_ref"`
+	ID                   string              `json:"id"`
+	BrokerName           string              `json:"broker_name"`
+	Bindable             bool                `json:"bindable"`
+	Plans                []ServicePlan       `json:"plans"`
+	PlanUpdatable        bool                `json:"updatable"`
+	Description          string              `json:"description"`
+}
+
+type ServicePlan struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}


### PR DESCRIPTION
In the 11/2-11/3/2016 sig-service-catalog discussions in Boulder at the Deis offices, the group came to consensus on what Kubernetes resources to use (the nouns) and how they’ll be used (the API). Both concepts are captured briefly in https://github.com/kubernetes-incubator/service-catalog/pull/31.

This PR adds the nouns to the steward framework codebase. Future patches will depend on this one and begin incorporating these nouns into the state machine to address the API changes. This patch should not be merged until these other patches are in place.

Work has been done to add similar code to the kubernetes-incubator repository