### PR TITLE
feat(k8s): Add instance control loop

### DIFF
--- a/fake/binder.go
+++ b/fake/binder.go
@@ -17,6 +17,7 @@ type Binder struct {
 // hardcoded BindResponse.
 func (b *Binder) Bind(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.BindRequest,
 ) (*framework.BindResponse, error) {
 

--- a/fake/deprovisioner.go
+++ b/fake/deprovisioner.go
@@ -18,6 +18,7 @@ type Deprovisioner struct {
 // DeprovisionRequest and returns a hardcoded DeprovisionResponse.
 func (d *Deprovisioner) Deprovision(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.DeprovisionRequest,
 ) (*framework.DeprovisionResponse, error) {
 

--- a/fake/provisioner.go
+++ b/fake/provisioner.go
@@ -18,6 +18,7 @@ type Provisioner struct {
 // returns a hardcoded ProvisionResponse.
 func (p *Provisioner) Provision(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.ProvisionRequest,
 ) (*framework.ProvisionResponse, error) {
 

--- a/fake/unbinder.go
+++ b/fake/unbinder.go
@@ -14,7 +14,11 @@ type Unbinder struct {
 
 // Unbind is the Unbinder interface implementation. It just records the UnbindRequest and returns
 // nil.
-func (u *Unbinder) Unbind(ctx context.Context, req *framework.UnbindRequest) error {
+func (u *Unbinder) Unbind(
+	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
+	req *framework.UnbindRequest,
+) error {
 	u.Reqs = append(u.Reqs, req)
 	return nil
 }

--- a/k8s/data/instance.go
+++ b/k8s/data/instance.go
@@ -7,8 +7,11 @@ import (
 )
 
 const (
-	InstanceKind       = "Instance"
-	InstanceKindPlural = "InstanceKind"
+	InstanceKind                           = "Instance"
+	InstanceKindPlural                     = "Instances"
+	InstanceStatePending     InstanceState = "Pending"
+	InstanceStateProvisioned InstanceState = "Provisioned"
+	InstanceStateFailed      InstanceState = "Failed"
 )
 
 type Instance struct {
@@ -33,9 +36,3 @@ type InstanceStatus struct {
 }
 
 type InstanceState string
-
-const (
-	InstanceStatePending     InstanceState = "Pending"
-	InstanceStateProvisioned InstanceState = "Provisioned"
-	InstanceStateFailed      InstanceState = "Failed"
-)

--- a/k8s/instance/logger.go
+++ b/k8s/instance/logger.go
@@ -1,0 +1,9 @@
+package instance
+
+import (
+	"github.com/juju/loggo"
+)
+
+var (
+	logger = loggo.GetLogger("k8s.instance")
+)

--- a/k8s/instance/logger_test.go
+++ b/k8s/instance/logger_test.go
@@ -1,0 +1,9 @@
+package instance
+
+import (
+	"github.com/juju/loggo"
+)
+
+func init() {
+	logger.SetLogLevel(loggo.TRACE)
+}

--- a/k8s/instance/loop.go
+++ b/k8s/instance/loop.go
@@ -1,0 +1,157 @@
+package instance
+
+import (
+	"context"
+	"errors"
+
+	"github.com/deis/steward-framework"
+	"github.com/deis/steward-framework/k8s/data"
+	"github.com/deis/steward-framework/k8s/refs"
+	"k8s.io/client-go/pkg/watch"
+)
+
+var (
+	ErrCancelled     = errors.New("stopped")
+	ErrNotAnInstance = errors.New("not an instance")
+	ErrWatchClosed   = errors.New("watch closed")
+)
+
+// RunLoop starts a blocking control loop that watches and takes action on instance resources
+func RunLoop(
+	ctx context.Context,
+	watchFn WatchInstanceFunc,
+	updateFn UpdateInstanceFunc,
+	getServiceClassFn refs.ServiceClassGetterFunc,
+	getBrokerFn refs.BrokerGetterFunc,
+	lifecycler framework.Lifecycler,
+) error {
+	// TODO: We should watch ALL namespaces; this is temporary.
+	// See https://github.com/deis/steward-framework/issues/29
+	watcher, err := watchFn("default")
+	if err != nil {
+		return err
+	}
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ErrCancelled
+		case evt, open := <-ch:
+			if !open {
+				logger.Errorf("the watch channel was closed")
+				return ErrWatchClosed
+			}
+			switch evt.Type {
+			case watch.Added:
+				if err := handleAddInstance(
+					ctx,
+					lifecycler,
+					updateFn,
+					getServiceClassFn,
+					getBrokerFn,
+					evt,
+				); err != nil {
+					// TODO: try the handler again.
+					// See https://github.com/deis/steward-framework/issues/26
+					logger.Errorf("add instance event handler failed (%s)", err)
+				}
+			case watch.Deleted:
+				if err := handleDeleteInstance(
+					ctx,
+					lifecycler,
+					getServiceClassFn,
+					getBrokerFn,
+					evt,
+				); err != nil {
+					// TODO: try the handler again.
+					// See https://github.com/deis/steward-framework/issues/26
+					logger.Errorf("delete instance event handler failed (%s)", err)
+				}
+			}
+		}
+	}
+}
+
+func handleAddInstance(
+	ctx context.Context,
+	lifecycler framework.Lifecycler,
+	updateFn UpdateInstanceFunc,
+	getServiceClassFn refs.ServiceClassGetterFunc,
+	getBrokerFn refs.BrokerGetterFunc,
+	evt watch.Event,
+) error {
+	instance, ok := evt.Object.(*data.Instance)
+	if !ok {
+		return ErrNotAnInstance
+	}
+	instance.Status.Status = data.InstanceStatePending
+	if _, err := updateFn(instance); err != nil {
+		return err
+	}
+	sc, err := getServiceClassFn(instance.Spec.ServiceClassRef)
+	if err != nil {
+		return err
+	}
+	b, err := getBrokerFn(sc.BrokerRef)
+	if err != nil {
+		return err
+	}
+	req := &framework.ProvisionRequest{
+		InstanceID:        instance.Spec.ID,
+		ServiceID:         sc.ID,
+		PlanID:            instance.Spec.PlanID,
+		AcceptsIncomplete: false,
+		Parameters:        instance.Spec.Parameters,
+	}
+	finalInstanceState := data.InstanceStateFailed
+	defer func() {
+		instance.Status.Status = finalInstanceState
+		if _, err = updateFn(instance); err != nil {
+			logger.Errorf("failed to update instance to state %s (%s)", finalInstanceState, err)
+		}
+	}()
+	_, err = lifecycler.Provision(ctx, b.Spec, req)
+	if err != nil {
+		return err
+	}
+	// TODO: Wait for async provision completion.
+	// See https://github.com/deis/steward-framework/issues/39
+	finalInstanceState = data.InstanceStateProvisioned
+	return nil
+}
+
+func handleDeleteInstance(
+	ctx context.Context,
+	lifecycler framework.Lifecycler,
+	getServiceClassFn refs.ServiceClassGetterFunc,
+	getBrokerFn refs.BrokerGetterFunc,
+	evt watch.Event,
+) error {
+	instance, ok := evt.Object.(*data.Instance)
+	if !ok {
+		return ErrNotAnInstance
+	}
+	sc, err := getServiceClassFn(instance.Spec.ServiceClassRef)
+	if err != nil {
+		return err
+	}
+	b, err := getBrokerFn(sc.BrokerRef)
+	if err != nil {
+		return err
+	}
+	req := &framework.DeprovisionRequest{
+		InstanceID:        instance.Spec.ID,
+		ServiceID:         sc.ID,
+		PlanID:            instance.Spec.PlanID,
+		AcceptsIncomplete: false,
+		Parameters:        instance.Spec.Parameters,
+	}
+	_, err = lifecycler.Deprovision(ctx, b.Spec, req)
+	if err != nil {
+		return err
+	}
+	// TODO: Wait for async deprovision completion
+	// See https://github.com/deis/steward-framework/issues/39
+	return nil
+}

--- a/k8s/instance/loop_test.go
+++ b/k8s/instance/loop_test.go
@@ -1,0 +1,163 @@
+package instance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arschles/assert"
+	"github.com/deis/steward-framework/fake"
+	"github.com/deis/steward-framework/k8s/data"
+	"github.com/deis/steward-framework/k8s/refs"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/watch"
+)
+
+func TestRunLoopCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	watcher, fakeWatcher := newFakeWatchInstanceFunc(nil)
+	updater, updated := newFakeUpdateInstanceFunc(nil)
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	lifecycler := &fake.Lifecycler{}
+	assert.Err(t, ErrCancelled, RunLoop(ctx, watcher, updater, getServiceClassFn, getBrokerFn, lifecycler))
+	assert.True(t, fakeWatcher.IsStopped(), "watcher isn't stopped")
+	assert.Equal(t, len(*updated), 0, "number of updated instances")
+}
+
+func TestRunLoopAddSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher, fakeWatcher := newFakeWatchInstanceFunc(nil)
+	updater, updated := newFakeUpdateInstanceFunc(nil)
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	provisioner := &fake.Provisioner{}
+	lifecycler := &fake.Lifecycler{
+		Provisioner: provisioner,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- RunLoop(ctx, watcher, updater, getServiceClassFn, getBrokerFn, lifecycler)
+	}()
+
+	fakeWatcher.Add(&data.Instance{})
+	fakeWatcher.Stop()
+
+	const errTimeout = 100 * time.Millisecond
+	select {
+	case err := <-errCh:
+		assert.Equal(t, len(provisioner.Reqs), 1, "number of provision requests")
+		assert.Equal(t, len(*updated), 2, "number of updated instances")
+		assert.Err(t, ErrWatchClosed, err)
+	case <-time.After(errTimeout):
+		t.Fatalf("RunLoop didn't return after %s", errTimeout)
+	}
+
+}
+
+func TestRunLoopDeleteSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher, fakeWatcher := newFakeWatchInstanceFunc(nil)
+	updater, updated := newFakeUpdateInstanceFunc(nil)
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	deprovisioner := &fake.Deprovisioner{}
+	lifecycler := &fake.Lifecycler{
+		Deprovisioner: deprovisioner,
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- RunLoop(ctx, watcher, updater, getServiceClassFn, getBrokerFn, lifecycler)
+	}()
+
+	fakeWatcher.Delete(&data.Instance{})
+	fakeWatcher.Stop()
+
+	const errTimeout = 100 * time.Millisecond
+	select {
+	case err := <-errCh:
+		assert.Equal(t, len(deprovisioner.Reqs), 1, "number of deprovision requests")
+		assert.Equal(t, len(*updated), 0, "number of updated instances")
+		assert.Err(t, ErrWatchClosed, err)
+	case <-time.After(errTimeout):
+		t.Fatalf("RunLoop didn't return after %s", errTimeout)
+	}
+
+}
+
+func TestHandleAddInstanceNotAnInstance(t *testing.T) {
+	ctx := context.Background()
+	updater, updated := newFakeUpdateInstanceFunc(nil)
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	provisioner := &fake.Provisioner{}
+	lifecycler := &fake.Lifecycler{
+		Provisioner: provisioner,
+	}
+	evt := watch.Event{
+		Type:   watch.Added,
+		Object: &api.Pod{},
+	}
+	err := handleAddInstance(ctx, lifecycler, updater, getServiceClassFn, getBrokerFn, evt)
+	assert.Err(t, ErrNotAnInstance, err)
+	assert.Equal(t, len(provisioner.Reqs), 0, "number of provision requests")
+	assert.Equal(t, len(*updated), 0, "number of updated instances")
+}
+
+func TestHandleAddInstanceSuccess(t *testing.T) {
+	ctx := context.Background()
+	updater, updated := newFakeUpdateInstanceFunc(nil)
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	provisioner := &fake.Provisioner{}
+	lifecycler := &fake.Lifecycler{
+		Provisioner: provisioner,
+	}
+	evt := watch.Event{
+		Type:   watch.Added,
+		Object: &data.Instance{},
+	}
+	err := handleAddInstance(ctx, lifecycler, updater, getServiceClassFn, getBrokerFn, evt)
+	assert.NoErr(t, err)
+	assert.Equal(t, len(provisioner.Reqs), 1, "number of provision requests")
+	assert.Equal(t, len(*updated), 2, "number of updated instances")
+}
+
+func TestHandleDeleteInstanceNotAnInstance(t *testing.T) {
+	ctx := context.Background()
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	deprovisioner := &fake.Deprovisioner{}
+	lifecycler := &fake.Lifecycler{
+		Deprovisioner: deprovisioner,
+	}
+	evt := watch.Event{
+		Type:   watch.Deleted,
+		Object: &api.Pod{},
+	}
+	err := handleDeleteInstance(ctx, lifecycler, getServiceClassFn, getBrokerFn, evt)
+	assert.Err(t, ErrNotAnInstance, err)
+	assert.Equal(t, len(deprovisioner.Reqs), 0, "number of deprovision requests")
+}
+
+func TestHandleDeleteInstanceSuccess(t *testing.T) {
+	ctx := context.Background()
+	getServiceClassFn := refs.NewFakeServiceClassGetterFunc(&data.ServiceClass{}, nil)
+	getBrokerFn := refs.NewFakeBrokerGetterFunc(&data.Broker{}, nil)
+	deprovisioner := &fake.Deprovisioner{}
+	lifecycler := &fake.Lifecycler{
+		Deprovisioner: deprovisioner,
+	}
+	evt := watch.Event{
+		Type:   watch.Deleted,
+		Object: &data.Instance{},
+	}
+	err := handleDeleteInstance(ctx, lifecycler, getServiceClassFn, getBrokerFn, evt)
+	assert.NoErr(t, err)
+	assert.Equal(t, len(deprovisioner.Reqs), 1, "number of deprovision requests")
+}

--- a/k8s/instance/update_instance_func.go
+++ b/k8s/instance/update_instance_func.go
@@ -1,0 +1,28 @@
+package instance
+
+import (
+	"github.com/deis/steward-framework/k8s/data"
+	"github.com/deis/steward-framework/k8s/restutil"
+	"k8s.io/client-go/rest"
+)
+
+// UpdateInstancdFunc is the function that can update an instance
+type UpdateInstanceFunc func(*data.Instance) (*data.Instance, error)
+
+// NewK8sUpdateInstanceFunc returns an UpdateInstanceFunc backed by a Kubernetes client
+func NewK8sUpdateInstanceFunc(restIface rest.Interface) UpdateInstanceFunc {
+	return func(newInstance *data.Instance) (*data.Instance, error) {
+		url := restutil.AbsPath(
+			restutil.APIVersionBase,
+			restutil.APIVersion,
+			true,
+			newInstance.Namespace,
+			data.InstanceKindPlural,
+		)
+		res := &data.Instance{}
+		if err := restIface.Put().AbsPath(url...).Body(newInstance).Do().Into(res); err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+}

--- a/k8s/instance/update_instance_func_test.go
+++ b/k8s/instance/update_instance_func_test.go
@@ -1,0 +1,16 @@
+package instance
+
+import (
+	"github.com/deis/steward-framework/k8s/data"
+)
+
+func newFakeUpdateInstanceFunc(retErr error) (UpdateInstanceFunc, *[]*data.Instance) {
+	instances := new([]*data.Instance)
+	return func(newInstance *data.Instance) (*data.Instance, error) {
+		if retErr != nil {
+			return nil, retErr
+		}
+		*instances = append(*instances, newInstance)
+		return newInstance, nil
+	}, instances
+}

--- a/k8s/instance/watch_instance_func.go
+++ b/k8s/instance/watch_instance_func.go
@@ -1,0 +1,25 @@
+package instance
+
+import (
+	"github.com/deis/steward-framework/k8s/data"
+	"github.com/deis/steward-framework/k8s/restutil"
+	"k8s.io/client-go/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+// WatchInstanceFunc is the function that returns a watch interface for instance resources
+type WatchInstanceFunc func(namespace string) (watch.Interface, error)
+
+// NewK8sWatchInstanceFunc returns a WatchInstanceFunc backed by a Kubernetes client
+func NewK8sWatchInstanceFunc(restIface rest.Interface) WatchInstanceFunc {
+	return func(namespace string) (watch.Interface, error) {
+		url := restutil.AbsPath(
+			restutil.APIVersionBase,
+			restutil.APIVersion,
+			true,
+			namespace,
+			data.InstanceKindPlural,
+		)
+		return restIface.Get().AbsPath(url...).Watch()
+	}
+}

--- a/k8s/instance/watch_instance_func_test.go
+++ b/k8s/instance/watch_instance_func_test.go
@@ -1,0 +1,16 @@
+package instance
+
+import (
+	"k8s.io/client-go/pkg/watch"
+)
+
+func newFakeWatchInstanceFunc(retErr error) (WatchInstanceFunc, *watch.FakeWatcher) {
+	fake := watch.NewFake()
+	fn := func(string) (watch.Interface, error) {
+		if retErr != nil {
+			return nil, retErr
+		}
+		return fake, nil
+	}
+	return fn, fake
+}


### PR DESCRIPTION
Closes #16 

This specifically excludes asynchronous provisioning and deprovisioning functionality. That will be addressed in a follow-up PR that addresses #39