### PR TITLE
fix(k8s/loops): Execute StartControlLoops in a goroutine

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -40,7 +40,7 @@ func Run(
 
 	errCh := make(chan error)
 
-	k8s.StartControlLoops(
+	go k8s.StartControlLoops(
 		ctx,
 		k8sClient,
 		cataloger,


### PR DESCRIPTION
The call to `k8s.StartControlLoops()` was blocking and stopping the API server from ever starting-- which in turn lead to failing health checks.