### PR TITLE
fix(logger): Improve logger names

### DIFF
--- a/k8s/binding/logger.go
+++ b/k8s/binding/logger.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("k8s.binding")
+	logger = loggo.GetLogger("framework.k8s.binding")
 )

--- a/k8s/broker/logger.go
+++ b/k8s/broker/logger.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("k8s.broker")
+	logger = loggo.GetLogger("framework.k8s.broker")
 )

--- a/k8s/instance/logger.go
+++ b/k8s/instance/logger.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("k8s.instance")
+	logger = loggo.GetLogger("framework.k8s.instance")
 )

--- a/k8s/logger.go
+++ b/k8s/logger.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("k8s")
+	logger = loggo.GetLogger("framework.k8s")
 )

--- a/web/api/logger.go
+++ b/web/api/logger.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	logger = loggo.GetLogger("web.api")
+	logger = loggo.GetLogger("framework.web.api")
 )


### PR DESCRIPTION
loggo loggers exist in a hierarchy and the dotted names denote where a logger exists within that hierarchy. Ordinarily, the "root logger" (`""`) is used for a `main` package and all other loggers' names reflect their location relative to that. Contextually, this information can be important when attempting to identify the source of a log message.

Since this framework doesn't contain a `main` package, but is used by executable programs that do (e.g. steward-cf), I feel things are kept a bit more tidy, and logs kept more accurate and informative if the logger names used throughout this project are all relative to `framework` and not `""`.